### PR TITLE
Parse sdss fits

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -30,7 +30,8 @@ For a more in depth overview, see the :ref:`SlowStart`.
    demo_id = object_ids[0]
    dr3.get_data_for_id(demo_id)
 
-   # Data is auto-formatted for use with the SNCosmo package. To disable this:
+   # Data is auto-formatted to be compatible with the SNCosmo package.
+   # To disable this:
    dr3.get_data_for_id(demo_id, format_table=False)
 
    # For convenience you can iterate over all tables

--- a/docs/source/module_docs/sndata.rst
+++ b/docs/source/module_docs/sndata.rst
@@ -27,5 +27,3 @@ Function Documentation
 
 .. autofunction:: get_zp
 .. autofunction:: delete_all_data
-.. autoclass:: sndata.CombinedDataset
-   :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyyaml
 requests
 tqdm
 sncosmo
+urllib

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pyyaml
 requests
 tqdm
 sncosmo
-urllib

--- a/sndata/_combine_data.py
+++ b/sndata/_combine_data.py
@@ -12,7 +12,7 @@ from . import _utils as utils
 
 
 def _reduce_id_mapping(id_list):
-    """Combine a list of sets by unioning any sets with shared elements
+    """Combine a list of sets by combining any sets with shared elements
 
     Args
         id_list (list[tuple[str]]): List of object IDs to join
@@ -264,7 +264,7 @@ class CombinedDataset:
 
         if len(obj_ids) <= 1:
             raise ValueError(
-                'Object IDs can only be joined in stes of 2 or more.')
+                'Object IDs can only be joined in sets of 2 or more.')
 
         self._joined_ids.append(set(obj_ids))
         self._joined_ids = _reduce_id_mapping(self._joined_ids)
@@ -278,7 +278,7 @@ class CombinedDataset:
 
         if len(obj_ids) <= 1:
             raise ValueError(
-                'Object IDs can only be joined in stes of 2 or more.')
+                'Object IDs can only be joined in sets of 2 or more.')
 
         obj_ids = set(obj_ids)
         for obj_id_set in self._joined_ids:

--- a/sndata/_factory_funcs.py
+++ b/sndata/_factory_funcs.py
@@ -14,17 +14,17 @@ from . import _utils as utils
 from ._utils import build_pbar
 
 
-def _register_filter(file_path, filt_name, force=False):
+def _register_filter(file_path, filter_name, force=False):
     """Registers filter profiles with sncosmo if not already registered
 
     Assumes the file at ``file_path`` is a two column, white space delimited
     ascii table.
 
     Args:
-        file_path (str): Path of an ascii table with wavelength (Angstrom)
-                          and transmission columns
-        filt_name (str): The name of the registered filter.
-        force    (bool): Whether to re-register a band if already registered
+        file_path   (str): Path of an ascii table with wavelength (Angstrom)
+                            and transmission columns
+        filter_name (str): The name of the registered filter.
+        force      (bool): Whether to re-register a band if already registered
     """
 
     # Get set of registered builtin and custom band passes
@@ -35,10 +35,10 @@ def _register_filter(file_path, filt_name, force=False):
         k[0] for k in sncosmo.bandpasses._BANDPASSES._instances)
 
     # Register the new bandpass
-    if filt_name not in available_bands:
-        filt_data = np.genfromtxt(file_path).T
-        band = sncosmo.Bandpass(filt_data[0], filt_data[1])
-        band.name = filt_name
+    if filter_name not in available_bands:
+        filter_data = np.genfromtxt(file_path).T
+        band = sncosmo.Bandpass(filter_data[0], filter_data[1])
+        band.name = filter_name
         sncosmo.register(band, force=force)
 
 

--- a/sndata/csp/dr1/__init__.py
+++ b/sndata/csp/dr1/__init__.py
@@ -9,7 +9,7 @@ after the time of B-band maximum light. (Source: Folatelli et al. 2013)
 
 Deviations from the standard UI:
   - This module provides spectroscopic data and as such the ``band_names``,
-  and ``lambda_effective`` attributes are not available.
+    and ``lambda_effective`` attributes are not available.
 
 Cuts on returned data:
   - None

--- a/sndata/csp/dr1/_data_parsing.py
+++ b/sndata/csp/dr1/_data_parsing.py
@@ -3,7 +3,6 @@
 
 """This module defines functions for accessing locally available data files."""
 
-from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -16,6 +15,7 @@ from ... import _utils as utils
 from ...exceptions import InvalidObjId
 
 
+# noinspection PyUnusedLocal
 def register_filters(force=False):
     """Register filters for this survey / data release with SNCosmo
 
@@ -40,7 +40,7 @@ def get_available_tables():
     return sorted(table_nums)
 
 
-@lru_cache(maxsize=None)
+@utils.lru_copy_cache(maxsize=None)
 @utils.require_data_path(meta.table_dir)
 def load_table(table_id):
     """Load a table from the data paper for this survey / data
@@ -120,7 +120,7 @@ def _read_file(path):
     return max_date, redshift, data
 
 
-# noinspection PyUnboundLocalVariable
+# noinspection PyUnusedLocal
 @utils.require_data_path(meta.spectra_dir)
 def get_data_for_id(obj_id, format_table=True):
     """Returns data for a given object ID

--- a/sndata/csp/dr1/_data_parsing.py
+++ b/sndata/csp/dr1/_data_parsing.py
@@ -106,10 +106,10 @@ def _read_file(path):
 
     # Add remaining columns. These values are constant for a single file
     # (i.e. a single spectrum) but vary across files (across spectra)
-    _, _, wrange, telescope, instrument = path.stem.split('_')
+    _, _, w_range, telescope, instrument = path.stem.split('_')
     date_col = Column(data=np.full(len(data), obs_date), name='date')
     epoch_col = Column(data=np.full(len(data), epoch), name='epoch')
-    wr_col = Column(data=np.full(len(data), wrange), name='wavelength_range')
+    wr_col = Column(data=np.full(len(data), w_range), name='wavelength_range')
     tel_col = Column(data=np.full(len(data), telescope), name='telescope')
     inst_col = Column(data=np.full(len(data), instrument), name='instrument')
     data.add_columns([date_col, epoch_col, wr_col, tel_col, inst_col])

--- a/sndata/csp/dr3/_data_parsing.py
+++ b/sndata/csp/dr3/_data_parsing.py
@@ -3,8 +3,6 @@
 
 """This module defines functions for accessing locally available data files."""
 
-from functools import lru_cache
-
 import numpy as np
 from astropy.io import ascii
 from astropy.table import Table
@@ -24,7 +22,7 @@ def get_available_tables():
     return sorted(int(path.stem.strip('table')) for path in file_list)
 
 
-@lru_cache(maxsize=None)
+@utils.lru_copy_cache(maxsize=None)
 @utils.require_data_path(meta.table_dir)
 def load_table(table_id):
     """Load a table from the data paper for this survey / data

--- a/sndata/des/sn3yr/_data_parsing.py
+++ b/sndata/des/sn3yr/_data_parsing.py
@@ -17,6 +17,7 @@ def get_available_tables():
     """Get table numbers for machine readable tables published in the paper
     for this data release"""
 
+    # noinspection SpellCheckingInspection
     return ['SALT2mu_DES+LOWZ_C11.FITRES', 'SALT2mu_DES+LOWZ_G10.FITRES']
 
 
@@ -34,6 +35,7 @@ def load_table(table_id):
     if table_id not in get_available_tables():
         raise ValueError(f'Table {table_id} is not available.')
 
+    # noinspection SpellCheckingInspection
     data = Table.read(
         str(meta.fits_dir / table_id),
         format='ascii',
@@ -110,8 +112,10 @@ def get_data_for_id(obj_id, format_table=True):
     if obj_id not in get_available_ids():
         raise InvalidObjId()
 
-    # Read in ascci data table for specified object
+    # Read in ascii data table for specified object
     file_path = meta.photometry_dir / f'des_{int(obj_id):08d}.dat'
+
+    # noinspection SpellCheckingInspection
     data = Table.read(
         file_path, format='ascii',
         data_start=27, data_end=-1,

--- a/sndata/des/sn3yr/_data_parsing.py
+++ b/sndata/des/sn3yr/_data_parsing.py
@@ -3,8 +3,6 @@
 
 """This module defines functions for accessing locally available data files."""
 
-from functools import lru_cache
-
 import numpy as np
 from astropy.table import Table
 
@@ -22,7 +20,7 @@ def get_available_tables():
     return ['SALT2mu_DES+LOWZ_C11.FITRES', 'SALT2mu_DES+LOWZ_G10.FITRES']
 
 
-@lru_cache(maxsize=None)
+@utils.lru_copy_cache(maxsize=None)
 @utils.require_data_path(meta.fits_dir)
 def load_table(table_id):
     """Load a table from the data paper for this survey / data

--- a/sndata/essence/narayan16/_data_parsing.py
+++ b/sndata/essence/narayan16/_data_parsing.py
@@ -3,7 +3,6 @@
 
 """This module defines functions for accessing locally available data files."""
 
-from functools import lru_cache
 from os import path as _path
 
 import numpy as np
@@ -24,7 +23,7 @@ def get_available_tables():
     return [6]
 
 
-@lru_cache(maxsize=None)
+@utils.lru_copy_cache(maxsize=None)
 @utils.require_data_path(meta.vizier_dir)
 def load_table(table_id):
     """Load a table from the data paper for this survey / data

--- a/sndata/sdss/sako18/_data_download.py
+++ b/sndata/sdss/sako18/_data_download.py
@@ -4,11 +4,10 @@
 """This module defines functions for downloading data."""
 
 import tarfile
-import zipfile
 
 from . import _meta as meta
 from ... import _factory_funcs as factory
-from ... import _utils as utils
+from ..._utils import check_url, download_file, download_tar
 
 delete_module_data = factory.factory_delete_module_data(meta.data_dir)
 
@@ -21,65 +20,61 @@ def download_module_data(force=False):
     """
 
     # Photometry
-    if (force or not meta.smp_dir.exists()) \
-            and utils.check_url(meta.smp_url):
-
+    if (force or not meta.smp_dir.exists()) and check_url(meta.smp_url):
         print('Downloading SMP data...')
-        utils.download_tar(
+        download_tar(
             url=meta.smp_url,
             out_dir=meta.data_dir,
             mode='r:gz')
 
     # SNANA files - including files specifying "bad" photometry data points
-    if (force or not meta.snana_dir.exists()) \
-            and utils.check_url(meta.snana_url):
-
+    if (force or not meta.snana_dir.exists()) and check_url(meta.snana_url):
         print('Downloading SNANA data...')
-        utils.download_tar(
+        download_tar(
             url=meta.snana_url,
             out_dir=meta.data_dir,
             mode='r:gz')
 
+        # Unzip file listing "bad" photometry
         outlier_archive = meta.snana_dir / 'SDSS_allCandidates+BOSS.tar.gz'
         with tarfile.open(str(outlier_archive), mode='r:gz') as data:
             data.extractall(str(outlier_archive.parent))
 
-    # Paper tables
-    if utils.check_url(meta.table_url):
-        for i, file_name in enumerate(meta.table_names):
+    # Tables from the published paper
+    print_tables = True  # Whether to print the status
+    if check_url(meta.table_url):
+        for file_name in meta.table_names:
+
             out_path = meta.table_dir / file_name
             if force or not out_path.exists():
-                if i == 0:
+                if print_tables:
                     print(f'Downloading tables...')
+                    print_tables = False
 
-                utils.download_file(
+                download_file(
                     url=meta.table_url + file_name,
                     out_file=out_path
                 )
 
     # Photometric filters
-    if utils.check_url(meta.filter_url):
-        for i, file_name in enumerate(meta.filter_file_names):
+    print_photometric = True
+    if check_url(meta.filter_url):
+        for file_name in meta.filter_file_names:
+
             out_path = meta.filter_dir / file_name
             if force or not out_path.exists():
-                if i == 0:
+                if print_photometric:
                     print(f'Downloading filters...')
+                    print_photometric = False
 
-                utils.download_file(
+                download_file(
                     url=meta.filter_url + file_name,
                     out_file=out_path
                 )
 
-    # if (force or not meta.spectra_dir.exists()) \
-    #         and utils.check_url(meta.spectra_url):
-    #     print('Downloading spectra...')
-    #     utils.download_tar(
-    #         url=meta.spectra_url,
-    #         out_dir=meta.data_dir,
-    #         mode='r:gz')
-
-    # Spectral data parsing requires IRAF so we use preparsed data instead
-    if force or not meta.spectra_dir.exists():
-        print('Unzipping spectra...')
-        with zipfile.ZipFile(meta.spectra_zip, 'r') as zip_ref:
-            zip_ref.extractall(meta.data_dir)
+    if (force or not meta.spectra_dir.exists()) and check_url(meta.spectra_url):
+        print('Downloading spectra...')
+        download_tar(
+            url=meta.spectra_url,
+            out_dir=meta.data_dir,
+            mode='r:gz')

--- a/sndata/sdss/sako18/_data_download.py
+++ b/sndata/sdss/sako18/_data_download.py
@@ -42,7 +42,7 @@ def download_module_data(force=False):
 
     # Tables from the published paper
     print_tables = True  # Whether to print the status
-    if check_url(meta.table_url):
+    if check_url(meta.base_url):
         for file_name in meta.table_names:
 
             out_path = meta.table_dir / file_name
@@ -52,7 +52,7 @@ def download_module_data(force=False):
                     print_tables = False
 
                 download_file(
-                    url=meta.table_url + file_name,
+                    url=meta.base_url + file_name,
                     out_file=out_path
                 )
 
@@ -72,6 +72,7 @@ def download_module_data(force=False):
                     out_file=out_path
                 )
 
+    # Fits file with spectra
     if (force or not meta.spectra_dir.exists()) and check_url(meta.spectra_url):
         print('Downloading spectra...')
         download_tar(

--- a/sndata/sdss/sako18/_data_download.py
+++ b/sndata/sdss/sako18/_data_download.py
@@ -4,6 +4,7 @@
 """This module defines functions for downloading data."""
 
 import tarfile
+import zipfile
 
 from . import _meta as meta
 from ... import _factory_funcs as factory
@@ -72,10 +73,16 @@ def download_module_data(force=False):
                     out_file=out_path
                 )
 
-    # Fits file with spectra
-    if (force or not meta.spectra_dir.exists()) and check_url(meta.spectra_url):
-        print('Downloading spectra...')
-        download_tar(
-            url=meta.spectra_url,
-            out_dir=meta.data_dir,
-            mode='r:gz')
+    # if (force or not meta.spectra_dir.exists()) \
+    #         and utils.check_url(meta.spectra_url):
+    #     print('Downloading spectra...')
+    #     utils.download_tar(
+    #         url=meta.spectra_url,
+    #         out_dir=meta.data_dir,
+    #         mode='r:gz')
+
+    # Spectral data parsing requires IRAF so we use preparsed data instead
+    if force or not meta.spectra_dir.exists():
+        print('Unzipping spectra...')
+        with zipfile.ZipFile(meta.spectra_zip, 'r') as zip_ref:
+            zip_ref.extractall(meta.data_dir)

--- a/sndata/sdss/sako18/_data_parsing.py
+++ b/sndata/sdss/sako18/_data_parsing.py
@@ -3,8 +3,6 @@
 
 """This module defines functions for accessing locally available data files."""
 
-from functools import lru_cache
-
 import numpy as np
 from astropy.table import Column, Table
 
@@ -30,7 +28,7 @@ def get_available_tables():
     return sorted(table_names, key=lambda x: 0 if x == 'master' else x)
 
 
-@lru_cache(maxsize=None)
+@utils.lru_copy_cache(maxsize=None)
 @utils.require_data_path(meta.table_dir)
 def load_table(table_id):
     """Load a table from the data paper for this survey / data

--- a/sndata/sdss/sako18/_meta.py
+++ b/sndata/sdss/sako18/_meta.py
@@ -5,6 +5,7 @@
 
 from itertools import product
 from pathlib import Path
+from urllib.parse import urljoin
 
 import numpy as np
 
@@ -12,31 +13,26 @@ _file_dir = Path(__file__).resolve().parent
 data_dir = _file_dir / 'data'
 
 # Define local paths of downloaded data
-filter_dir = data_dir / 'doi_2010_filters/'
-table_dir = data_dir / 'tables/'  # Paper tables
-smp_dir = data_dir / 'SMP_Data/'  # SMP data files
-snana_dir = data_dir / 'SDSS_dataRelease-snana/'  # SNANA files
+filter_dir = data_dir / 'doi_2010_filters/'  # Transmission filters
+table_dir = data_dir / 'tables/'  # Tables from the published paper
+smp_dir = data_dir / 'SMP_Data/'  # SMP data files (photometric light-curves)
+snana_dir = data_dir / 'SDSS_dataRelease-snana/'  # SNANA files including list of outliers
 outlier_path = snana_dir / 'SDSS_allCandidates+BOSS/SDSS_allCandidates+BOSS.IGNORE'  # Outlier data
-spectra_zip = _file_dir / 'Spectra_txt.zip'
-spectra_dir = data_dir / 'Spectra_txt'  # spectra txt files
+spectra_dir = data_dir / 'Spectra'  # spectra fits files
 
 # Define urls and file names for remote data
 filter_url = 'http://www.ioa.s.u-tokyo.ac.jp/~doi/sdss/'
-table_url = 'https://portal.nersc.gov/project/dessn/SDSS/dataRelease/'
-table_names = [
-    'master_data.txt', 'Table2.txt', 'Table9.txt', 'Table11.txt', 'Table12.txt'
-]
 
-smp_url = 'https://portal.nersc.gov/project/dessn/SDSS/dataRelease/SMP_Data.tar.gz'
-snana_url = 'https://portal.nersc.gov/project/dessn/SDSS/dataRelease/SDSS_dataRelease-snana.tar.gz'
+base_url = 'https://portal.nersc.gov/project/dessn/SDSS/dataRelease/'
+table_names = 'master_data.txt', 'Table2.txt', 'Table9.txt', 'Table11.txt', 'Table12.txt'
+smp_url = urljoin(base_url, 'SMP_Data.tar.gz')
+snana_url = urljoin(base_url, 'SDSS_dataRelease-snana.tar.gz')
+spectra_url = urljoin(base_url, 'Spectra.tar.gz')
 
 # Filter information
 # Effective wavelengths for SDSS filters ugriz in angstroms
 # are available at https://www.sdss.org/instruments/camera/#Filters
-band_names = tuple(
-    f'sdss_sako18_{b}{c}' for b, c in product('ugriz', '123456')
-)
-
+band_names = tuple(f'sdss_sako18_{b}{c}' for b, c in product('ugriz', '123456'))
 filter_file_names = tuple(f'{b}{c}.dat' for b, c in product('ugriz', '123456'))
 zero_point = [2.5 * np.log10(3631) for _ in band_names]
 lambda_effective = (
@@ -44,4 +40,5 @@ lambda_effective = (
     4686, 4686, 4686, 4686, 4686, 4686,
     6166, 6166, 6166, 6166, 6166, 6166,
     7480, 7480, 7480, 7480, 7480, 7480,
-    8932, 8932, 8932, 8932, 8932, 8932)
+    8932, 8932, 8932, 8932, 8932, 8932
+)

--- a/sndata/sdss/sako18/_meta.py
+++ b/sndata/sdss/sako18/_meta.py
@@ -11,17 +11,16 @@ import numpy as np
 _file_dir = Path(__file__).resolve().parent
 data_dir = _file_dir / 'data'
 
-# Define local paths of published data
+# Define local paths of downloaded data
 filter_dir = data_dir / 'doi_2010_filters/'
 table_dir = data_dir / 'tables/'  # Paper tables
 smp_dir = data_dir / 'SMP_Data/'  # SMP data files
 snana_dir = data_dir / 'SDSS_dataRelease-snana/'  # SNANA files
 outlier_path = snana_dir / 'SDSS_allCandidates+BOSS/SDSS_allCandidates+BOSS.IGNORE'  # Outlier data
-
 spectra_zip = _file_dir / 'Spectra_txt.zip'
 spectra_dir = data_dir / 'Spectra_txt'  # spectra txt files
 
-# Define urls for remote data
+# Define urls and file names for remote data
 filter_url = 'http://www.ioa.s.u-tokyo.ac.jp/~doi/sdss/'
 table_url = 'https://portal.nersc.gov/project/dessn/SDSS/dataRelease/'
 table_names = [

--- a/sndata/sdss/sako18/_meta.py
+++ b/sndata/sdss/sako18/_meta.py
@@ -18,7 +18,8 @@ table_dir = data_dir / 'tables/'  # Tables from the published paper
 smp_dir = data_dir / 'SMP_Data/'  # SMP data files (photometric light-curves)
 snana_dir = data_dir / 'SDSS_dataRelease-snana/'  # SNANA files including list of outliers
 outlier_path = snana_dir / 'SDSS_allCandidates+BOSS/SDSS_allCandidates+BOSS.IGNORE'  # Outlier data
-spectra_dir = data_dir / 'Spectra'  # spectra fits files
+spectra_dir = data_dir / 'Spectra_txt'  # spectra files
+spectra_zip = _file_dir / 'Spectra_txt.zip'  # compressed spectra files
 
 # Define urls and file names for remote data
 filter_url = 'http://www.ioa.s.u-tokyo.ac.jp/~doi/sdss/'

--- a/sndata/sdss/sako18spec/_data_parsing.py
+++ b/sndata/sdss/sako18spec/_data_parsing.py
@@ -103,7 +103,6 @@ def get_data_for_id(obj_id, format_table=True):
         out_data.meta['z_err'] = None
 
     out_data.meta['dtype'] = 'spectroscopic'
-    out_data.meta['spec_id'] = spec_id
     out_data.meta['comments'] = \
         'z represents CMB corrected redshift of the supernova.'
 

--- a/sndata/sdss/sako18spec/_parse_iraf.py
+++ b/sndata/sdss/sako18spec/_parse_iraf.py
@@ -1,0 +1,252 @@
+"""Read IRAF (echelle) spectrum in multispec format from a FITS file.
+
+History:
+    Created by Rick White based on my IDL readechelle.pro, 2012 August 15
+    Converted from Python2 to Python 3 by Daniel Perrefort in January 2020
+"""
+
+import numpy as np
+from astropy.io import fits
+
+
+def nonlinearwave(nwave, specstr, verbose=False):
+    """Compute non-linear wavelengths from multispec string
+
+    Returns wavelength array and dispersion fields.
+    Raises a ValueError if it can't understand the dispersion string.
+
+    Args:
+        nwave       ():
+        specstr     ():
+        verbose (bool): Whether to print status messages
+
+    Returns:
+          An array of wavelength values
+    """
+
+    fields = specstr.split()
+    if int(fields[2]) != 2:
+        raise ValueError(f'Not nonlinear dispersion: dtype={fields[2]}')
+
+    if len(fields) < 12:
+        raise ValueError(f'Bad spectrum format (only {len(fields)} fields)')
+
+    ftype = int(fields[11])
+    if ftype == 3:  # cubic spline
+
+        if len(fields) < 15:
+            raise ValueError(f'Bad spline format (only {len(fields)} fields)')
+
+        npieces = int(fields[12])
+        pmin = float(fields[13])
+        pmax = float(fields[14])
+
+        if verbose:
+            print(f'Dispersion is order-{npieces} cubic spline')
+
+        if len(fields) != 15 + npieces + 3:
+            raise ValueError(f'Bad order-{npieces} spline format ({len(fields)}')
+
+        coeff = np.asarray(fields[15:], dtype=float)
+        # normalized x coordinates
+        s = (np.arange(nwave, dtype=float) + 1 - pmin) / (pmax - pmin) * npieces
+        j = s.astype(int).clip(0, npieces - 1)
+        a = (j + 1) - s
+        b = s - j
+        x0 = a ** 3
+        x1 = 1 + 3 * a * (1 + a * b)
+        x2 = 1 + 3 * b * (1 + a * b)
+        x3 = b ** 3
+        wave = coeff[j] * x0 + coeff[j + 1] * x1 + coeff[j + 2] * x2 + coeff[j + 3] * x3
+
+    elif ftype == 1 or ftype == 2:
+        # chebyshev or legendre polynomial
+        # legendre not tested yet
+
+        if len(fields) < 15:
+            raise ValueError(f'Bad polynomial format (only {len(fields)} fields)')
+
+        order = int(fields[12])
+        pmin = float(fields[13])
+        pmax = float(fields[14])
+        if verbose:
+            if ftype == 1:
+                print(f'Dispersion is order-{order} Chebyshev polynomial')
+            else:
+                print(f'Dispersion is order-{order} Legendre polynomial (NEEDS TEST)')
+
+        if len(fields) != 15 + order:
+            # raise ValueError('Bad order-%d polynomial format (%d fields)' % (order, len(fields)))
+            if verbose:
+                print(f'Bad order-{order} polynomial format ({len(fields)} fields)')
+                print(f'Changing order from {order} to {len(fields) - 15}')
+
+            order = len(fields) - 15
+
+        coeff = np.asarray(fields[15:], dtype=float)
+
+        # normalized x coordinates
+        pmiddle = (pmax + pmin) / 2
+        prange = pmax - pmin
+        x = (np.arange(nwave, dtype=float) + 1 - pmiddle) / (prange / 2)
+        p0 = np.ones(nwave, dtype=float)
+        p1 = x
+        wave = p0 * coeff[0] + p1 * coeff[1]
+        for i in range(2, order):
+            if ftype == 1:
+                # chebyshev
+                p2 = 2 * x * p1 - p0
+
+            else:
+                # legendre
+                p2 = ((2 * i - 1) * x * p1 - (i - 1) * p0) / i
+
+            wave = wave + p2 * coeff[i]
+            p0 = p1
+            p1 = p2
+
+    else:
+        raise ValueError(
+            'Cannot handle dispersion function of type %d' % ftype)
+
+    return wave
+
+
+def readmultispec(fitsfile, reform=True, quiet=False):
+    """Read IRAF echelle spectrum in multispec format from a FITS file
+
+    Can read most multispec formats including linear, log, cubic spline,
+    Chebyshev or Legendre dispersion spectra
+
+    If reform is true, a single spectrum dimensioned 4,1,NWAVE is returned
+    as 4,NWAVE (this is the default.)  If reform is false, it is returned as
+    a 3-D array.
+    """
+
+    with fits.open(fitsfile) as fh:
+        header = fh[0].header
+        flux = fh[0].data
+
+    temp = flux.shape
+    nwave = temp[-1]
+
+    if len(temp) == 1:
+        nspec = 1
+
+    else:
+        nspec = temp[-2]
+
+    # first try linear dispersion
+    try:
+        crval1 = header['crval1']
+        crpix1 = header['crpix1']
+        cd1_1 = header['cd1_1']
+        ctype1 = header['ctype1']
+        if ctype1.strip() == 'LINEAR':
+            wavelen = np.zeros((nspec, nwave), dtype=float)
+            ww = (np.arange(nwave, dtype=float) + 1 - crpix1) * cd1_1 + crval1
+            for i in range(nspec):
+                wavelen[i, :] = ww
+
+            # handle log spacing too
+            dcflag = header.get('dc-flag', 0)
+            if dcflag == 1:
+                wavelen = 10.0 ** wavelen
+                if not quiet:
+                    print('Dispersion is linear in log wavelength')
+
+            elif dcflag == 0:
+                if not quiet:
+                    print('Dispersion is linear')
+
+            else:
+                raise ValueError(f'Dispersion not linear or log (DC-FLAG={dcflag})')
+
+            if nspec == 1 and reform:
+                # get rid of unity dimensions
+                flux = np.squeeze(flux)
+                wavelen.shape = (nwave,)
+
+            return {'flux': flux, 'wavelen': wavelen}
+
+    except KeyError:
+        pass
+
+    # get wavelength parameters from multispec keywords
+    try:
+        wat2 = header['wat2_*']
+
+    except KeyError:
+        raise ValueError('Cannot decipher header, need either WAT2_ or CRVAL keywords')
+
+    # concatenate them all together into one big string
+    watstr = []
+    for i in range(len(wat2)):
+        # hack to fix the fact that older pyfits versions (< 3.1)
+        # strip trailing blanks from string values in an apparently
+        # irrecoverable way
+        # v = wat2[i].value
+        v = wat2[i]
+        v = v + (" " * (68 - len(v)))  # restore trailing blanks
+        watstr.append(v)
+
+    watstr = ''.join(watstr)
+
+    # find all the spec#="..." strings
+    specstr = [''] * nspec
+    for i in range(nspec):
+        sname = 'spec' + str(i + 1)
+        p1 = watstr.find(sname)
+        p2 = watstr.find('"', p1)
+        p3 = watstr.find('"', p2 + 1)
+        if p1 < 0 or p3 < 0:
+            raise ValueError(f'Cannot find {sname} in WAT2_* keyword')
+
+        specstr[i] = watstr[p2 + 1:p3]
+
+    wparms = np.zeros((nspec, 9), dtype=float)
+    for i in range(nspec):
+        w1 = np.asarray(specstr[i].split(), dtype=float)
+        wparms[i, :] = w1[:9]
+        if w1[2] == -1:
+            raise ValueError(f'Spectrum {i + 1} has no wavelength calibration (type={w1[2]})')
+            # elif w1[6] != 0:
+            #    raise ValueError('Spectrum %d has non-zero redshift (z=%f)' % (i+1,w1[6]))
+
+    wavelen = np.zeros((nspec, nwave), dtype=float)
+    wavefields = [None] * nspec
+    for i in range(nspec):
+        # if i in skipped_orders:
+        #    continue
+        verbose = (not quiet) and (i == 0)
+        if wparms[i, 2] == 0 or wparms[i, 2] == 1:
+            # simple linear or log spacing
+            wavelen[i, :] = np.arange(nwave, dtype=float) * wparms[i, 4] + wparms[i, 3]
+
+            if wparms[i, 2] == 1:
+                wavelen[i, :] = 10.0 ** wavelen[i, :]
+                if verbose:
+                    print('Dispersion is linear in log wavelength')
+
+            elif verbose:
+                print('Dispersion is linear')
+
+        else:
+            # non-linear wavelengths
+            wavelen[i, :], wavefields[i] = nonlinearwave(nwave, specstr[i], verbose=verbose)
+
+        wavelen *= 1.0 + wparms[i, 6]
+
+        if verbose:
+            print(f'Correcting for redshift: z={wparms[i, 6]}')
+
+    if nspec == 1 and reform:
+        # get rid of unity dimensions
+        wavelen.shape = (nwave,)
+
+    return {'flux': flux, 'wavelen': wavelen}
+
+
+if __name__ == '__main__':
+    p = '/Users/daniel/Github/sndata/sndata/sdss/sako18/data/Spectra/gal739-59.fits'
+    print(readmultispec(p))

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -146,6 +146,20 @@ class DataParsingTestBase(TestCase):
         is_unique = len(np.unique(obj_ids)) == len(obj_ids)
         self.assertTrue(is_unique)
 
+    def _test_cache_not_mutated(self):
+        """Test mutating returned tables does not mutate them in the cache"""
+
+        table_id = self.module.get_available_tables()[0]
+        original_table = self.module.load_table(table_id)
+        original_table_len = len(original_table)
+        original_table.remove_row(0)
+
+        new_table = self.module.load_table(table_id)
+
+        self.assertEqual(
+            original_table_len, len(new_table),
+            'Table length was mutated in memory')
+
 
 class DocumentationTestBase(TestCase):
     """Generic tests for a given survey

--- a/tests/test_csp_dr1.py
+++ b/tests/test_csp_dr1.py
@@ -33,6 +33,9 @@ class DataParsing(DataParsingTestBase):
     def test_unique_ids(self):
         self._test_unique_ids()
 
+    def test_cache_not_mutated(self):
+        self._test_cache_not_mutated()
+
 
 class Documentation(DocumentationTestBase):
     """Tests for the des.SN3YR module"""

--- a/tests/test_csp_dr3.py
+++ b/tests/test_csp_dr3.py
@@ -75,6 +75,9 @@ class DataParsing(DataParsingTestBase):
     def test_unique_ids(self):
         self._test_unique_ids()
 
+    def test_cache_not_mutated(self):
+        self._test_cache_not_mutated()
+
 
 class Documentation(DocumentationTestBase):
     """Tests for the des.SN3YR module"""

--- a/tests/test_des_sn3yr.py
+++ b/tests/test_des_sn3yr.py
@@ -42,6 +42,9 @@ class DataParsing(DataParsingTestBase):
     def test_unique_ids(self):
         self._test_unique_ids()
 
+    def test_cache_not_mutated(self):
+        self._test_cache_not_mutated()
+
 
 class Documentation(DocumentationTestBase):
     """Tests for the des.SN3YR module"""

--- a/tests/test_essence_narayan16.py
+++ b/tests/test_essence_narayan16.py
@@ -42,6 +42,9 @@ class DataParsing(DataParsingTestBase):
     def test_unique_ids(self):
         self._test_unique_ids()
 
+    def test_cache_not_mutated(self):
+        self._test_cache_not_mutated()
+
 
 class Documentation(DocumentationTestBase):
     """Tests for the des.SN3YR module"""

--- a/tests/test_sdss_sako18.py
+++ b/tests/test_sdss_sako18.py
@@ -42,6 +42,9 @@ class DataParsing(DataParsingTestBase):
     def test_unique_ids(self):
         self._test_unique_ids()
 
+    def test_cache_not_mutated(self):
+        self._test_cache_not_mutated()
+
 
 class Documentation(DocumentationTestBase):
     """Tests for the des.SN3YR module"""

--- a/tests/test_sdss_sako18spec.py
+++ b/tests/test_sdss_sako18spec.py
@@ -33,6 +33,9 @@ class DataParsing(DataParsingTestBase):
     def test_unique_ids(self):
         self._test_unique_ids()
 
+    def test_cache_not_mutated(self):
+        self._test_cache_not_mutated()
+
 
 class Documentation(DocumentationTestBase):
     """Tests for the des.SN3YR module"""


### PR DESCRIPTION
This branch was intended to parse the SDSS .fits files directly instead of using compressed fits files. Unfortunately, I have yet to figure out how to reliably parse the wavelength values from the IRAF multispec format in Python. However, there have been a few useful bug fixes in this branch that should be merged into master.

Changes:
 - Code organizational edits
 - `sdss.sako18.download_module_data` no longer prints erroneous status messages when skipping downloaded data
 - Tables are copied when returned from memory cache. This protects against mutation.