### PR TITLE
Add custom data path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
 
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
 
 matrix:
   include:
+    - python: 3.5
     - python: 3.6
     - python: 3.7
-      dist: xenial
-      sudo: true
+    - python: 3.8
 
 install:
   - pip install -r requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019, Daniel Perrefort'
 author = 'Daniel Perrefort'
 
 # The short X.Y version
-version = '0.9.1'
+version = '0.9.2'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -47,3 +47,9 @@ package, install each dependency from ``requirements.txt`` and then try again.
 
 .. _pip package manager: https://pip.pypa.io/en/stable/
 .. _GitHub: https://github.com/djperrefort/sndata
+
+Configuring Data Storage
+------------------------
+
+By default data downloaded by **sndata** is stored in the installation directory. This can be changed to a custom
+directory by specifying the value `SNDATA_DIR` in your environment (i.e., in you `.bash_profile` or `.bashrc` file).

--- a/sndata/__init__.py
+++ b/sndata/__init__.py
@@ -9,7 +9,7 @@ from . import csp, des, essence, jla, sdss
 from ._combine_data import CombinedDataset
 from .exceptions import ObservedDataTypeError as _ObservedDataTypeError
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 __author__ = 'Daniel Perrefort'
 __license__ = 'GPL 3.0'
 

--- a/sndata/_utils.py
+++ b/sndata/_utils.py
@@ -4,6 +4,7 @@
 """This module provides utilities used by various submodules."""
 
 import functools
+import os
 import tarfile
 from copy import deepcopy
 from functools import wraps
@@ -237,3 +238,24 @@ def read_vizier_table_descriptions(readme_path):
             table_descriptions[table_num] = table_desc
 
     return table_descriptions
+
+
+def create_data_dir(survey_name, release):
+    """Create the data directory for a given survey and release
+
+    Directories are created in ``environ['SNDATA_DIR']`` using lowercase names
+    and underscores instead of spaces.
+
+    Args:
+        survey_name (str): The name of a survey (e.g., csp)
+        release     (str): The name of a data release from the survey (e.g., dr3)
+
+    Returns:
+        A Path object representing the created directory
+    """
+
+    safe_survey = survey_name.lower().replace(' ', '_')
+    safe_release = release.lower().replace(' ', '_')
+    path = Path(os.environ['SNDATA_DIR']).resolve() / safe_survey / safe_release
+    path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/sndata/csp/dr1/__init__.py
+++ b/sndata/csp/dr1/__init__.py
@@ -23,11 +23,12 @@ from ._data_parsing import get_data_for_id
 from ._data_parsing import iter_data
 from ._data_parsing import load_table
 from ._data_parsing import register_filters
-
-survey_name = 'Carnegie Supernova Project'
-survey_abbrev = 'CSP'
-release = 'dr1'
-survey_url = 'https://csp.obs.carnegiescience.edu/news-items/CSP_spectra_DR1'
-data_type = 'spectroscopic'
-publications = ('Folatelli et al. 2013',)
-ads_url = 'https://ui.adsabs.harvard.edu/abs/2013ApJ...773...53F/abstract'
+from ._meta import (
+    ads_url,
+    data_type,
+    publications,
+    release,
+    survey_abbrev,
+    survey_name,
+    survey_url
+)

--- a/sndata/csp/dr1/_meta.py
+++ b/sndata/csp/dr1/_meta.py
@@ -6,9 +6,11 @@
 import os
 from pathlib import Path
 
-_data_dir = os.environ.get('SNDATA_DIR', __file__)
-_base_dir = Path(_data_dir).resolve().parent
-data_dir = _base_dir / 'data'
+if 'SNDATA_DIR' in os.environ:
+    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+
+else:
+    data_dir = Path(__file__).resolve().parent / 'data'
 
 # Define local paths of published data
 spectra_dir = data_dir / 'CSP_spectra_DR1'  # DR1 spectra

--- a/sndata/csp/dr1/_meta.py
+++ b/sndata/csp/dr1/_meta.py
@@ -3,10 +3,12 @@
 
 """This module specifies file meta and urls used by this submodule."""
 
+import os
 from pathlib import Path
 
-_file_dir = Path(__file__).resolve().parent
-data_dir = _file_dir / 'data'
+_data_dir = os.environ.get('SNDATA_DIR', __file__)
+_base_dir = Path(_data_dir).resolve().parent
+data_dir = _base_dir / 'data'
 
 # Define local paths of published data
 spectra_dir = data_dir / 'CSP_spectra_DR1'  # DR1 spectra

--- a/sndata/csp/dr1/_meta.py
+++ b/sndata/csp/dr1/_meta.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3.7
 # -*- coding: UTF-8 -*-
 
-"""This module specifies file meta and urls used by this submodule."""
+"""This file specifies file meta and urls used by the parent module."""
 
 import os
 from pathlib import Path
 
+from ... import _utils as utils
+
+# General metadata
+survey_name = 'Carnegie Supernova Project'
+survey_abbrev = 'CSP'
+release = 'dr1'
+survey_url = 'https://csp.obs.carnegiescience.edu/news-items/CSP_spectra_DR1'
+data_type = 'spectroscopic'
+publications = ('Folatelli et al. 2013',)
+ads_url = 'https://ui.adsabs.harvard.edu/abs/2013ApJ...773...53F/abstract'
+
 if 'SNDATA_DIR' in os.environ:
-    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+    data_dir = utils.create_data_dir(survey_name, release)
 
 else:
     data_dir = Path(__file__).resolve().parent / 'data'

--- a/sndata/csp/dr3/__init__.py
+++ b/sndata/csp/dr3/__init__.py
@@ -27,12 +27,14 @@ from ._data_parsing import get_data_for_id
 from ._data_parsing import iter_data
 from ._data_parsing import load_table
 from ._data_parsing import register_filters
-from ._meta import band_names, lambda_effective
-
-survey_name = 'Carnegie Supernova Project'
-survey_abbrev = 'CSP'
-release = 'dr3'
-survey_url = 'https://csp.obs.carnegiescience.edu/news-items/csp-dr3-photometry-released'
-data_type = 'photometric'
-publications = ('Krisciunas et al. 2017',)
-ads_url = 'https://ui.adsabs.harvard.edu/abs/2017AJ....154..278K/abstract'
+from ._meta import (
+    ads_url,
+    band_names,
+    data_type,
+    lambda_effective,
+    publications,
+    release,
+    survey_abbrev,
+    survey_name,
+    survey_url
+)

--- a/sndata/csp/dr3/_meta.py
+++ b/sndata/csp/dr3/_meta.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3.7
 # -*- coding: UTF-8 -*-
 
-"""This module specifies file meta and urls used by this submodule."""
+"""This file specifies file meta and urls used by the parent module."""
 
 import os
 from pathlib import Path
 
+from ... import _utils as utils
+
+# General metadata
+survey_name = 'Carnegie Supernova Project'
+survey_abbrev = 'CSP'
+release = 'dr3'
+survey_url = 'https://csp.obs.carnegiescience.edu/news-items/csp-dr3-photometry-released'
+data_type = 'photometric'
+publications = ('Krisciunas et al. 2017',)
+ads_url = 'https://ui.adsabs.harvard.edu/abs/2017AJ....154..278K/abstract'
+
 if 'SNDATA_DIR' in os.environ:
-    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+    data_dir = utils.create_data_dir(survey_name, release)
 
 else:
     data_dir = Path(__file__).resolve().parent / 'data'

--- a/sndata/csp/dr3/_meta.py
+++ b/sndata/csp/dr3/_meta.py
@@ -3,10 +3,12 @@
 
 """This module specifies file meta and urls used by this submodule."""
 
+import os
 from pathlib import Path
 
-_file_dir = Path(__file__).resolve().parent
-data_dir = _file_dir / 'data'
+_data_dir = os.environ.get('SNDATA_DIR', __file__)
+_base_dir = Path(_data_dir).resolve().parent
+data_dir = _base_dir / 'data'
 
 # Define local paths of published data
 photometry_dir = data_dir / 'DR3'  # DR3 Light Curves

--- a/sndata/csp/dr3/_meta.py
+++ b/sndata/csp/dr3/_meta.py
@@ -6,9 +6,11 @@
 import os
 from pathlib import Path
 
-_data_dir = os.environ.get('SNDATA_DIR', __file__)
-_base_dir = Path(_data_dir).resolve().parent
-data_dir = _base_dir / 'data'
+if 'SNDATA_DIR' in os.environ:
+    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+
+else:
+    data_dir = Path(__file__).resolve().parent / 'data'
 
 # Define local paths of published data
 photometry_dir = data_dir / 'DR3'  # DR3 Light Curves

--- a/sndata/des/sn3yr/__init__.py
+++ b/sndata/des/sn3yr/__init__.py
@@ -22,17 +22,14 @@ from ._data_parsing import get_data_for_id
 from ._data_parsing import iter_data
 from ._data_parsing import load_table
 from ._data_parsing import register_filters
-from ._meta import band_names, lambda_effective
-
-survey_name = 'Dark Energy Survey'
-survey_abbrev = 'DES'
-release = 'sn3yr'
-survey_url = 'https://des.ncsa.illinois.edu/'
-data_type = 'photometric'
-publications = (
-    'Burke et al. 2017',
-    'Brout et al. 2019',
-    'Brout et al. 2018-SYS'
+from ._meta import (
+    ads_url,
+    band_names,
+    data_type,
+    lambda_effective,
+    publications,
+    release,
+    survey_abbrev,
+    survey_name,
+    survey_url
 )
-
-ads_url = 'https://ui.adsabs.harvard.edu/abs/2019ApJ...874..106B/abstract'

--- a/sndata/des/sn3yr/_meta.py
+++ b/sndata/des/sn3yr/_meta.py
@@ -1,15 +1,29 @@
 #!/usr/bin/env python3.7
 # -*- coding: UTF-8 -*-
 
-"""Download any data files that do not exist locally and define file paths to
-the local data for use by the parent module.
-"""
+"""This file specifies file meta and urls used by the parent module."""
 
 import os
 from pathlib import Path
 
+from ... import _utils as utils
+
+# General metadata
+survey_name = 'Dark Energy Survey'
+survey_abbrev = 'DES'
+release = 'sn3yr'
+survey_url = 'https://des.ncsa.illinois.edu/'
+data_type = 'photometric'
+publications = (
+    'Burke et al. 2017',
+    'Brout et al. 2019',
+    'Brout et al. 2018-SYS'
+)
+
+ads_url = 'https://ui.adsabs.harvard.edu/abs/2019ApJ...874..106B/abstract'
+
 if 'SNDATA_DIR' in os.environ:
-    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+    data_dir = utils.create_data_dir(survey_name, release)
 
 else:
     data_dir = Path(__file__).resolve().parent / 'data'

--- a/sndata/des/sn3yr/_meta.py
+++ b/sndata/des/sn3yr/_meta.py
@@ -5,10 +5,12 @@
 the local data for use by the parent module.
 """
 
+import os
 from pathlib import Path
 
-_file_dir = Path(__file__).resolve().parent
-data_dir = _file_dir / 'data'
+_data_dir = os.environ.get('SNDATA_DIR', __file__)
+_base_dir = Path(_data_dir).resolve().parent
+data_dir = _base_dir / 'data'
 
 # Define local paths of published data
 filter_dir = data_dir / '01-FILTERS' / 'DECam'

--- a/sndata/des/sn3yr/_meta.py
+++ b/sndata/des/sn3yr/_meta.py
@@ -8,9 +8,11 @@ the local data for use by the parent module.
 import os
 from pathlib import Path
 
-_data_dir = os.environ.get('SNDATA_DIR', __file__)
-_base_dir = Path(_data_dir).resolve().parent
-data_dir = _base_dir / 'data'
+if 'SNDATA_DIR' in os.environ:
+    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+
+else:
+    data_dir = Path(__file__).resolve().parent / 'data'
 
 # Define local paths of published data
 filter_dir = data_dir / '01-FILTERS' / 'DECam'

--- a/sndata/essence/narayan16/__init__.py
+++ b/sndata/essence/narayan16/__init__.py
@@ -22,12 +22,14 @@ from ._data_parsing import get_data_for_id
 from ._data_parsing import iter_data
 from ._data_parsing import load_table
 from ._data_parsing import register_filters
-from ._meta import band_names, lambda_effective
-
-survey_name = 'Equation of State: Supernovae trace Cosmic Expansion'
-survey_abbrev = 'ESSENCE'
-release = 'narayan16'
-survey_url = 'http://www.ctio.noao.edu/essence/'
-data_type = 'photometric'
-publications = ('Narayan et al. 2016',)
-ads_url = 'https://ui.adsabs.harvard.edu/abs/2016ApJS..224....3N/abstract'
+from ._meta import (
+    ads_url,
+    band_names,
+    data_type,
+    lambda_effective,
+    publications,
+    release,
+    survey_abbrev,
+    survey_name,
+    survey_url
+)

--- a/sndata/essence/narayan16/_meta.py
+++ b/sndata/essence/narayan16/_meta.py
@@ -5,10 +5,12 @@
 the local data for use by the parent module.
 """
 
+import os
 from pathlib import Path
 
-_file_dir = Path(__file__).resolve().parent
-data_dir = _file_dir / 'data'
+_data_dir = os.environ.get('SNDATA_DIR', __file__)
+_base_dir = Path(_data_dir).resolve().parent
+data_dir = _base_dir / 'data'
 
 # Define local paths of published data
 vizier_dir = data_dir / 'vizier'

--- a/sndata/essence/narayan16/_meta.py
+++ b/sndata/essence/narayan16/_meta.py
@@ -8,9 +8,11 @@ the local data for use by the parent module.
 import os
 from pathlib import Path
 
-_data_dir = os.environ.get('SNDATA_DIR', __file__)
-_base_dir = Path(_data_dir).resolve().parent
-data_dir = _base_dir / 'data'
+if 'SNDATA_DIR' in os.environ:
+    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+
+else:
+    data_dir = Path(__file__).resolve().parent / 'data'
 
 # Define local paths of published data
 vizier_dir = data_dir / 'vizier'

--- a/sndata/essence/narayan16/_meta.py
+++ b/sndata/essence/narayan16/_meta.py
@@ -1,18 +1,28 @@
 #!/usr/bin/env python3.7
 # -*- coding: UTF-8 -*-
 
-"""Download any data files that do not exist locally and define file paths to
-the local data for use by the parent module.
-"""
+"""This file specifies file meta and urls used by the parent module."""
 
 import os
 from pathlib import Path
 
+from ... import _utils as utils
+
+# General metadata
+survey_name = 'Equation of State: Supernovae trace Cosmic Expansion'
+survey_abbrev = 'ESSENCE'
+release = 'narayan16'
+survey_url = 'http://www.ctio.noao.edu/essence/'
+data_type = 'photometric'
+publications = ('Narayan et al. 2016',)
+ads_url = 'https://ui.adsabs.harvard.edu/abs/2016ApJS..224....3N/abstract'
+
 if 'SNDATA_DIR' in os.environ:
-    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+    data_dir = utils.create_data_dir(survey_name, release)
 
 else:
     data_dir = Path(__file__).resolve().parent / 'data'
+
 
 # Define local paths of published data
 vizier_dir = data_dir / 'vizier'

--- a/sndata/jla/betoule14/__init__.py
+++ b/sndata/jla/betoule14/__init__.py
@@ -29,12 +29,14 @@ from ._data_parsing import get_data_for_id
 from ._data_parsing import iter_data
 from ._data_parsing import load_table
 from ._data_parsing import register_filters
-from ._meta import band_names, lambda_effective
-
-survey_name = 'Joint Light-curve Analysis'
-survey_abbrev = 'JLA'
-release = 'betoule14'
-survey_url = 'http://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html'
-data_type = 'photometric'
-publications = ('Betoule et al. (2014)',)
-ads_url = 'https://ui.adsabs.harvard.edu/abs/2014A%26A...568A..22B/abstract'
+from ._meta import (
+    ads_url,
+    band_names,
+    data_type,
+    lambda_effective,
+    publications,
+    release,
+    survey_abbrev,
+    survey_name,
+    survey_url
+)

--- a/sndata/jla/betoule14/_meta.py
+++ b/sndata/jla/betoule14/_meta.py
@@ -1,18 +1,30 @@
 #!/usr/bin/env python3.7
 # -*- coding: UTF-8 -*-
 
-"""This module specifies file meta and urls used by this submodule."""
+"""This file specifies file meta and urls used by the parent module."""
 
 import os
 from pathlib import Path
 
 import numpy as np
 
+from ... import _utils as utils
+
+# General metadata
+survey_name = 'Joint Light-curve Analysis'
+survey_abbrev = 'JLA'
+release = 'betoule14'
+survey_url = 'http://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html'
+data_type = 'photometric'
+publications = ('Betoule et al. (2014)',)
+ads_url = 'https://ui.adsabs.harvard.edu/abs/2014A%26A...568A..22B/abstract'
+
 if 'SNDATA_DIR' in os.environ:
-    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+    data_dir = utils.create_data_dir(survey_name, release)
 
 else:
     data_dir = Path(__file__).resolve().parent / 'data'
+
 
 # Define local paths of published data
 photometry_dir = data_dir / 'jla_light_curves'  # Photometry data

--- a/sndata/jla/betoule14/_meta.py
+++ b/sndata/jla/betoule14/_meta.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 import numpy as np
 
-_data_dir = os.environ.get('SNDATA_DIR', __file__)
-_base_dir = Path(_data_dir).resolve().parent
-data_dir = _base_dir / 'data'
+if 'SNDATA_DIR' in os.environ:
+    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+
+else:
+    data_dir = Path(__file__).resolve().parent / 'data'
 
 # Define local paths of published data
 photometry_dir = data_dir / 'jla_light_curves'  # Photometry data

--- a/sndata/jla/betoule14/_meta.py
+++ b/sndata/jla/betoule14/_meta.py
@@ -3,12 +3,14 @@
 
 """This module specifies file meta and urls used by this submodule."""
 
+import os
 from pathlib import Path
 
 import numpy as np
 
-_file_dir = Path(__file__).resolve().parent
-data_dir = _file_dir / 'data'
+_data_dir = os.environ.get('SNDATA_DIR', __file__)
+_base_dir = Path(_data_dir).resolve().parent
+data_dir = _base_dir / 'data'
 
 # Define local paths of published data
 photometry_dir = data_dir / 'jla_light_curves'  # Photometry data

--- a/sndata/sdss/sako18/__init__.py
+++ b/sndata/sdss/sako18/__init__.py
@@ -27,12 +27,14 @@ from ._data_parsing import get_data_for_id
 from ._data_parsing import iter_data
 from ._data_parsing import load_table
 from ._data_parsing import register_filters
-from ._meta import band_names, lambda_effective
-
-survey_name = 'Sloan Digital Sky Survey'
-survey_abbrev = 'SDSS'
-release = 'sako18'
-survey_url = 'https://portal.nersc.gov/project/dessn/SDSS/dataRelease/'
-data_type = 'photometric'
-publications = ('Sako et al. (2018)',)
-ads_url = 'https://ui.adsabs.harvard.edu/abs/2018PASP..130f4002S/abstract'
+from ._meta import (
+    ads_url,
+    band_names,
+    data_type,
+    lambda_effective,
+    publications,
+    release,
+    survey_abbrev,
+    survey_name,
+    survey_url
+)

--- a/sndata/sdss/sako18/_meta.py
+++ b/sndata/sdss/sako18/_meta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3.7
 # -*- coding: UTF-8 -*-
 
-"""This module specifies file meta and urls used by this submodule."""
+"""This file specifies file meta and urls used by the parent module."""
 
 import os
 from itertools import product
@@ -10,9 +10,21 @@ from urllib.parse import urljoin
 
 import numpy as np
 
+from ... import _utils as utils
+
+# General metadata
+survey_name = 'Sloan Digital Sky Survey'
+survey_abbrev = 'SDSS'
+release = 'sako18'
+survey_url = 'https://portal.nersc.gov/project/dessn/SDSS/dataRelease/'
+data_type = 'photometric'
+publications = ('Sako et al. (2018)',)
+ads_url = 'https://ui.adsabs.harvard.edu/abs/2018PASP..130f4002S/abstract'
+
+
 _file_dir = Path(__file__).resolve().parent
 if 'SNDATA_DIR' in os.environ:
-    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+    data_dir = utils.create_data_dir(survey_name, release)
 
 else:
     data_dir = _file_dir / 'data'

--- a/sndata/sdss/sako18/_meta.py
+++ b/sndata/sdss/sako18/_meta.py
@@ -10,10 +10,12 @@ from urllib.parse import urljoin
 
 import numpy as np
 
-_data_dir = os.environ.get('SNDATA_DIR', __file__)
-_base_dir = Path(_data_dir).resolve().parent
 _file_dir = Path(__file__).resolve().parent
-data_dir = _base_dir / 'data'
+if 'SNDATA_DIR' in os.environ:
+    data_dir = Path(os.environ['SNDATA_DIR']).resolve() / 'data'
+
+else:
+    data_dir = _file_dir / 'data'
 
 # Define local paths of downloaded data
 filter_dir = data_dir / 'doi_2010_filters/'  # Transmission filters

--- a/sndata/sdss/sako18/_meta.py
+++ b/sndata/sdss/sako18/_meta.py
@@ -3,14 +3,17 @@
 
 """This module specifies file meta and urls used by this submodule."""
 
+import os
 from itertools import product
 from pathlib import Path
 from urllib.parse import urljoin
 
 import numpy as np
 
+_data_dir = os.environ.get('SNDATA_DIR', __file__)
+_base_dir = Path(_data_dir).resolve().parent
 _file_dir = Path(__file__).resolve().parent
-data_dir = _file_dir / 'data'
+data_dir = _base_dir / 'data'
 
 # Define local paths of downloaded data
 filter_dir = data_dir / 'doi_2010_filters/'  # Transmission filters


### PR DESCRIPTION
Allows users to specify where downloaded data should be stored by defining `SNDATA_DIR` in their environment. Data is still stored in the installation directory by default. 

If `SNDATA_DIR` is specified, then data is organized according to the file structure `$SNDATA_DIR/<survey_name>/<release_name>`. These directories are created automatically on the import of a given data release. 