### PR TITLE
Removes comments from meta data

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019, Daniel Perrefort'
 author = 'Daniel Perrefort'
 
 # The short X.Y version
-version = '0.9.4'
+version = '0.9.5'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/sndata/__init__.py
+++ b/sndata/__init__.py
@@ -9,7 +9,7 @@ from . import csp, des, essence, jla, sdss
 from ._combine_data import CombinedDataset
 from .exceptions import ObservedDataTypeError as _ObservedDataTypeError
 
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 __author__ = 'Daniel Perrefort'
 __license__ = 'GPL 3.0'
 

--- a/sndata/csp/dr1/_data_parsing.py
+++ b/sndata/csp/dr1/_data_parsing.py
@@ -157,7 +157,7 @@ def get_data_for_id(obj_id, format_table=True):
     out_table.meta['dec'] = None
     out_table.meta['z'] = redshift
     out_table.meta['z_err'] = None
-    out_table.meta.move_to_end('comments')
+    del out_table.meta['comments']
 
     return out_table
 

--- a/sndata/csp/dr3/_data_parsing.py
+++ b/sndata/csp/dr3/_data_parsing.py
@@ -95,7 +95,6 @@ def parse_snoopy_data(path):
         out_table.meta['dec'] = float(dec)
         out_table.meta['z'] = float(z)
         out_table.meta['z_err'] = None
-        out_table.meta['comments'] = None
 
         # Read photometric data from the rest of the file
         band = None

--- a/sndata/des/sn3yr/_data_parsing.py
+++ b/sndata/des/sn3yr/_data_parsing.py
@@ -133,10 +133,7 @@ def get_data_for_id(obj_id, format_table=True):
         data.meta['z'] = float(table_meta_data[13].split()[1])
         data.meta['z_err'] = float(table_meta_data[13].split()[3])
         data.meta['dtype'] = 'photometric'
-        data.meta['comments'] = \
-            'z represents CMB corrected redshift of the supernova.'
-
-        data.meta.move_to_end('comments')
+        del data.meta['comments']
 
     if format_table:
         data = _format_sncosmo_table(data)

--- a/sndata/essence/narayan16/_data_parsing.py
+++ b/sndata/essence/narayan16/_data_parsing.py
@@ -95,7 +95,7 @@ def get_data_for_id(obj_id, format_table=True):
     data_table.meta['obj_id'] = data_table.meta.pop('objid')
 
     # Remove column names from table comments
-    data_table.meta['comments'].pop()
+    del data_table.meta['comments']
 
     if format_table:
         data_table = _format_table(data_table)

--- a/sndata/jla/betoule14/_data_parsing.py
+++ b/sndata/jla/betoule14/_data_parsing.py
@@ -164,9 +164,8 @@ def get_data_for_id(obj_id, format_table=True):
     out_table.meta['z_err'] = None
     out_table.meta.update(meta_data)
 
-    out_table.meta.pop('comments')
-    out_table.meta.pop('SN')
-    out_table.meta['comments'] = 'z represents the heliocentric redshift'
+    del out_table.meta['comments']
+    del out_table.meta['SN']
 
     return out_table
 

--- a/sndata/sdss/sako18/_data_parsing.py
+++ b/sndata/sdss/sako18/_data_parsing.py
@@ -171,9 +171,8 @@ def get_data_for_id(obj_id, format_table=True):
     data.meta['z'] = table_meta_data['zCMB'][0]
     data.meta['z_err'] = table_meta_data['zerrCMB'][0]
     data.meta['dtype'] = 'photometric'
-    data.meta['comments'] = \
-        'z represents CMB corrected redshift of the supernova.'
     data.meta['classification'] = table_meta_data['Classification'][0]
+    del data.meta['comments']
 
     outlier_list = get_outliers().get(obj_id, [])
     if outlier_list:

--- a/sndata/sdss/sako18spec/_data_parsing.py
+++ b/sndata/sdss/sako18spec/_data_parsing.py
@@ -103,9 +103,6 @@ def get_data_for_id(obj_id, format_table=True):
         out_data.meta['z_err'] = None
 
     out_data.meta['dtype'] = 'spectroscopic'
-    out_data.meta['comments'] = \
-        'z represents CMB corrected redshift of the supernova.'
-
     return out_data
 
 

--- a/sndata/snls/balland09/_data_parsing.py
+++ b/sndata/snls/balland09/_data_parsing.py
@@ -144,9 +144,7 @@ def get_data_for_id(obj_id, format_table=True):
     out_table.meta['dec'] = dec
     out_table.meta['z'] = z
     out_table.meta['z_err'] = z_err
-
-    out_table.meta.pop('comments')
-    out_table.meta['comments'] = ''
+    del out_table.meta['comments']
 
     return out_table
 


### PR DESCRIPTION
Having a 'comments' key plays havoc when trying to write astropy tables (See [7357](https://github.com/astropy/astropy/issues/7357)). To avoid this, I'm removing comments from all table metadata.