### PR TITLE
Convert SDSS spectra time values to JD

### DIFF
--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -1,0 +1,12 @@
+Change Log
+==========
+
+This page documents any API changes between different versions of the
+``sndata`` package.
+
+V 1.0.1
+-------
+
+- For consistency with the rest of the package, time values in data tables
+  returned by the ``sndata.sdss.Sako18Spec`` class have been converted from
+  UNIX timestamps to Julian day.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,6 +86,7 @@ Available Data
    :maxdepth: 0
 
    Overview<self>
+   change_log
 
 .. toctree::
    :hidden:

--- a/sndata/__init__.py
+++ b/sndata/__init__.py
@@ -11,7 +11,7 @@ from . import csp, des, essence, jla, sdss, snls
 from ._combine_data import CombinedDataset, get_zp
 from .exceptions import ObservedDataTypeError as _ObservedDataTypeError
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __author__ = 'Daniel Perrefort'
 __license__ = 'GPL 3.0'
 

--- a/sndata/csp/_dr1.py
+++ b/sndata/csp/_dr1.py
@@ -78,6 +78,9 @@ class DR1(SpectroscopicRelease, DefaultParser):
     before to over 150 days after the time of B-band maximum light.
     (Source: Folatelli et al. 2013)
 
+    .. important:: The DR1 spectra are both published and returned by sndata
+       in units of rest frame wavelength.
+
     Deviations from the standard UI:
         - None
 

--- a/sndata/sdss/_sako18spec.py
+++ b/sndata/sdss/_sako18spec.py
@@ -138,7 +138,11 @@ class Sako18Spec(SpectroscopicRelease):
             if format_table:
                 date_with_timezone = summary_row['Date'] + '+0000'
                 date = datetime.strptime(date_with_timezone, '%Y-%m-%d%z')
-                data['time'] = date.timestamp()
+
+                unix_time = date.timestamp()
+                january_1_1970_in_julian = 2440587.5
+                day_in_seconds = 24 * 60 * 60
+                data['time'] = (unix_time / day_in_seconds) + january_1_1970_in_julian
 
             else:
                 data['date'] = observed_date


### PR DESCRIPTION
For consistency with the rest of the package, time values in data tables returned by the ``sndata.sdss.Sako18Spec`` class have been converted from UNIX timestamps to Julian day.

A change log has also been added to the docs.